### PR TITLE
feat: add normalization env wrapper

### DIFF
--- a/gex/__init__.py
+++ b/gex/__init__.py
@@ -1,0 +1,3 @@
+from .normalization import NormalizeEnv
+
+__all__ = ["NormalizeEnv"]

--- a/gex/normalization.py
+++ b/gex/normalization.py
@@ -1,0 +1,70 @@
+import numpy as np
+import gymnasium as gym
+
+
+class NormalizeEnv(gym.Wrapper):
+    """Environment wrapper that normalizes observations and actions.
+
+    Actions passed to this wrapper are assumed to be normalized. They are
+    unnormalized using the provided action statistics before being passed to the
+    underlying environment. Observations returned from the environment are
+    normalized before being returned to the caller.
+
+    The wrapper expects optional mean and standard deviation vectors for both
+    observations and actions. If provided, their shapes must match the
+    corresponding space shapes of the environment.
+    """
+
+    def __init__(
+        self,
+        env: gym.Env,
+        obs_mean: np.ndarray | None = None,
+        obs_std: np.ndarray | None = None,
+        action_mean: np.ndarray | None = None,
+        action_std: np.ndarray | None = None,
+    ) -> None:
+        super().__init__(env)
+
+        if (obs_mean is None) != (obs_std is None):
+            raise ValueError("obs_mean and obs_std must both be provided or both be None")
+        if (action_mean is None) != (action_std is None):
+            raise ValueError(
+                "action_mean and action_std must both be provided or both be None"
+            )
+
+        if obs_mean is not None:
+            obs_mean = np.asarray(obs_mean, dtype=np.float32)
+            obs_std = np.asarray(obs_std, dtype=np.float32)
+            assert obs_mean.shape == env.observation_space.shape
+            assert obs_std.shape == env.observation_space.shape
+
+        if action_mean is not None:
+            action_mean = np.asarray(action_mean, dtype=np.float32)
+            action_std = np.asarray(action_std, dtype=np.float32)
+            assert action_mean.shape == env.action_space.shape
+            assert action_std.shape == env.action_space.shape
+
+        self._obs_mean = obs_mean
+        self._obs_std = obs_std
+        self._action_mean = action_mean
+        self._action_std = action_std
+
+    def reset(self, **kwargs):
+        obs, info = self.env.reset(**kwargs)
+        if self._obs_mean is not None:
+            obs = self._normalize_obs(obs)
+        return obs, info
+
+    def step(self, action):
+        if self._action_mean is not None:
+            action = self._unnormalize_action(action)
+        obs, reward, terminated, truncated, info = self.env.step(action)
+        if self._obs_mean is not None:
+            obs = self._normalize_obs(obs)
+        return obs, reward, terminated, truncated, info
+
+    def _normalize_obs(self, obs):
+        return (obs - self._obs_mean) / self._obs_std
+
+    def _unnormalize_action(self, action):
+        return action * self._action_std + self._action_mean

--- a/gex/normalization.py
+++ b/gex/normalization.py
@@ -52,19 +52,19 @@ class NormalizeEnv(gym.Wrapper):
     def reset(self, **kwargs):
         obs, info = self.env.reset(**kwargs)
         if self._obs_mean is not None:
-            obs = self._normalize_obs(obs)
+            obs = self._normalize(obs, self._obs_mean, self._obs_std)
         return obs, info
 
     def step(self, action):
         if self._action_mean is not None:
-            action = self._unnormalize_action(action)
+            action = self._unnormalize(action, self._action_mean, self._action_std)
         obs, reward, terminated, truncated, info = self.env.step(action)
         if self._obs_mean is not None:
-            obs = self._normalize_obs(obs)
+            obs = self._normalize(obs, self._obs_mean, self._obs_std)
         return obs, reward, terminated, truncated, info
 
-    def _normalize_obs(self, obs):
-        return (obs - self._obs_mean) / self._obs_std
+    def _unnormalize(self, x, mean, std):
+        return x * std + mean
 
-    def _unnormalize_action(self, action):
-        return action * self._action_std + self._action_mean
+    def _normalize(self, x, mean, std):
+        return (x - mean) / std


### PR DESCRIPTION
## Summary
- add `NormalizeEnv` wrapper that unnormalizes actions and normalizes observations using optional mean/std vectors
- expose wrapper in package init

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cf62e80cc8329a9a3287e011df793