### PR TITLE
Add wrapper mapping is_success to success info key

### DIFF
--- a/src/gex/__init__.py
+++ b/src/gex/__init__.py
@@ -1,3 +1,4 @@
 from .norm import NormalizeEnv
+from .success import SuccessInfoWrapper
 
-__all__ = ["NormalizeEnv"]
+__all__ = ["NormalizeEnv", "SuccessInfoWrapper"]

--- a/src/gex/success.py
+++ b/src/gex/success.py
@@ -1,0 +1,24 @@
+import gymnasium as gym
+
+
+class SuccessInfoWrapper(gym.Wrapper):
+    """Environment wrapper that renames ``info['is_success']`` to ``info['success']``.
+
+    Some environments return an ``is_success`` flag in the ``info`` dictionary. This
+    wrapper makes such environments compatible with interfaces expecting the key
+    ``success`` instead by copying the value and removing the original key.
+    """
+
+    def reset(self, **kwargs):
+        obs, info = self.env.reset(**kwargs)
+        if "is_success" in info:
+            info = dict(info)
+            info["success"] = info.pop("is_success")
+        return obs, info
+
+    def step(self, action):
+        obs, reward, terminated, truncated, info = self.env.step(action)
+        if "is_success" in info:
+            info = dict(info)
+            info["success"] = info.pop("is_success")
+        return obs, reward, terminated, truncated, info


### PR DESCRIPTION
## Summary
- add SuccessInfoWrapper to map `info['is_success']` to `info['success']`
- export SuccessInfoWrapper in package `__init__`

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4decd23fc8329aeb1d0042879e265