### PR TITLE
Add wrapper to flatten observations

### DIFF
--- a/src/gex/__init__.py
+++ b/src/gex/__init__.py
@@ -1,4 +1,5 @@
+from .flatten import FlattenObservationWrapper
 from .norm import NormalizeEnv
 from .success import SuccessInfoWrapper
 
-__all__ = ["NormalizeEnv", "SuccessInfoWrapper"]
+__all__ = ["FlattenObservationWrapper", "NormalizeEnv", "SuccessInfoWrapper"]

--- a/src/gex/flatten.py
+++ b/src/gex/flatten.py
@@ -1,0 +1,28 @@
+import numpy as np
+import gymnasium as gym
+
+
+class FlattenObservationWrapper(gym.ObservationWrapper):
+    """Environment wrapper that flattens observations to 1D vectors.
+
+    Observations returned by the wrapped environment are flattened using
+    ``numpy.ravel`` before being passed to the caller. The observation space is
+    adjusted accordingly.
+    """
+
+    def __init__(self, env: gym.Env) -> None:
+        super().__init__(env)
+        if not isinstance(env.observation_space, gym.spaces.Box):
+            raise TypeError(
+                "FlattenObservationWrapper only supports Box observation spaces"
+            )
+        low = np.asarray(env.observation_space.low).ravel()
+        high = np.asarray(env.observation_space.high).ravel()
+        self.observation_space = gym.spaces.Box(
+            low=low,
+            high=high,
+            dtype=env.observation_space.dtype,
+        )
+
+    def observation(self, observation):
+        return np.asarray(observation).ravel()


### PR DESCRIPTION
## Summary
- add `FlattenObservationWrapper` to flatten observations from Box spaces into 1D vectors
- export the new wrapper from the package

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a74dbfbbc48329adfe3f6f0597fa7e